### PR TITLE
観戦日記のpublishedカラムを削除

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -58,7 +58,7 @@ class DiariesController < ApplicationController
   end
 
   def set_diaries
-    @diaries = Diary.where('user_id = ?', current_user.id)
+    @diaries = Diary.where(user_id: current_user.id).order(id: :desc)
   end
 
   def diary_params

--- a/app/javascript/new-game.vue
+++ b/app/javascript/new-game.vue
@@ -50,6 +50,7 @@
           </div>
         </div>
 
+        <div class='diary-header diary-header__title' v-if='result'>{{ cardMonth }}月{{ cardDate }}日の試合</div>
         <div class='diary__item' v-if='result'>
           <h2 class='diary__item-title'>スコア</h2>
           <table class='table game-result-table score-board-table is-fullwidth is-bordered' id='score-board'>

--- a/app/javascript/stylesheets/styles/_diaries-item.scss
+++ b/app/javascript/stylesheets/styles/_diaries-item.scss
@@ -71,3 +71,29 @@
   font-size: .75rem;
   font-weight: 400;
  }
+
+.diary-link-selector {
+  display: flex;
+}
+
+.diary-link-selector__item {
+  font-size: 1rem;
+  
+  > div {
+    padding: .5rem;
+  }
+  &:nth-child(1) {
+    flex: 1;
+    text-align: left;
+    color: $link;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  &:nth-child(2) {
+    flex: 1;
+    text-align: right;
+    color: $link;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -5,4 +5,12 @@ class Diary < ApplicationRecord
   belongs_to :game
   has_many :links, dependent: :destroy
   accepts_nested_attributes_for :links, allow_destroy: true
+
+  def previous
+    Diary.where('id < ? and user_id = ?', id, user_id).order(id: :desc).first
+  end
+
+  def next
+    Diary.where('id > ? and user_id = ?', id, user_id).order(id: :asc).first
+  end
 end

--- a/app/views/diaries/show.html.slim
+++ b/app/views/diaries/show.html.slim
@@ -115,6 +115,15 @@ header.page-header
                           = link.title
 
             .diary__item
+              .diary-link-selector
+                .diary-link-selector__item
+                  - if @diary.previous.present?
+                    = link_to '< 前の日記', diary_path(current_user.username, @diary.previous)
+                .diary-link-selector__item
+                  - if @diary.next.present?
+                    = link_to '次の日記 >', diary_path(current_user.username, @diary.next)
+                    
+            .diary__item
               .buttons
                 = link_to t('button.edit'), edit_diary_path(params[:username]), class: 'button is-primary'
               = link_to t('button.back'), :back, class: 'button is-small'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -58,7 +58,7 @@ ja:
     resend_unlock_email: ロック解除メールの再送
   title:
     diaries: 観戦日記
-    new_diary: 観戦日記の新規作成
+    new_diary: 観戦日記の作成
     show_diary: 観戦日記詳細
     edit_diary: 観戦日記の編集
     log_in: ログイン

--- a/db/fixtures/diaries.yml
+++ b/db/fixtures/diaries.yml
@@ -1,47 +1,39 @@
 g202202261211_user1:
-  published: false
   comment: 'test_user1の日記です。'
   game: g202202261211
   user_id: 100
 
 d2022031992_user1:
-  published: false
   comment: 'test_user1の日記です。'
   game: g2022031992
   user_id: 100
 
 g2022032118_user1:
-  published: false
   comment: 'test_user1の日記です。'
   game: g2022032118
   user_id: 100
 
 g2022032614_user1:
-  published: false
   comment: 'test_user1の日記です。'
   game: g2022032614
   user_id: 100
 
 g2022032714_user1:
-  published: false
   comment: 'test_user1の日記です。'
   game: g2022032714
   user_id: 100
 
 g2022032614_user2:
-  published: false
   comment: 'test_user2の日記です。'
   game: g2022032614
   user_id: 200
 
 g2022040123_user2:
-  published: false
   comment: 'test_user2の日記です。'
   game: g2022040123
   user_id: 200
 
 g2022040315_user2:
-  published: false
   comment: 'test_user2の日記です。'
   game: g2022040315
   user_id: 200

--- a/db/migrate/20220420233635_remove_published_from_diaries.rb
+++ b/db/migrate/20220420233635_remove_published_from_diaries.rb
@@ -1,0 +1,5 @@
+class RemovePublishedFromDiaries < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :diaries, :published, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_04_114822) do
+ActiveRecord::Schema.define(version: 2022_04_20_233635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,6 @@ ActiveRecord::Schema.define(version: 2022_04_04_114822) do
   end
 
   create_table "diaries", force: :cascade do |t|
-    t.boolean "published", default: false, null: false
     t.text "comment"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/factories/diaries.rb
+++ b/spec/factories/diaries.rb
@@ -3,6 +3,5 @@
 FactoryBot.define do
   factory :diary do
     comment { '菊池の守備がいい！' }
-    published { 'false' }
   end
 end

--- a/spec/models/diary_spec.rb
+++ b/spec/models/diary_spec.rb
@@ -4,10 +4,35 @@ require 'rails_helper'
 
 RSpec.describe Diary, type: :model do
   describe '正常系' do
+    before do
+      @game = FactoryBot.build(:game)
+      @user = FactoryBot.build(:user)
+    end
+
     it '登録成功' do
-      game = FactoryBot.build(:game)
-      user = FactoryBot.build(:user)
-      expect(FactoryBot.build(:diary, game: game, user: user)).to be_valid
+      expect(FactoryBot.build(:diary, game: @game, user: @user)).to be_valid
+    end
+
+    context 'previousメソッドを実行すると' do
+      before do
+        @diary1 = FactoryBot.create(:diary, game: @game, user: @user)
+        @diary2 = FactoryBot.create(:diary, game: @game, user: @user, id: @diary1.id + 1)
+      end
+
+      it '前の日記を取得できる' do
+        expect(@diary2.previous).to eq @diary1
+      end
+    end
+
+    context 'nextメソッドを実行すると' do
+      before do
+        @diary1 = FactoryBot.create(:diary, game: @game, user: @user)
+        @diary2 = FactoryBot.create(:diary, game: @game, user: @user, id: @diary1.id + 1)
+      end
+
+      it '次の日記を取得できる' do
+        expect(@diary1.next).to eq @diary2
+      end
     end
   end
 end


### PR DESCRIPTION
# やったこと
- カラム追加は簡単とのことなので、Diaryのpublishedカラムを残さずに削除することにした
- 観戦日記詳細ページに「前の日記」「次の日記」リンクを作成した
- 観戦日記はDiary.idで並べるようにした
- 観戦日記作成ページで試合を選択したあと、試合日を表示するようにした

# After
![スクリーンショット 2022-04-21 14 36 56](https://user-images.githubusercontent.com/58643754/164381937-fdff3751-2006-46e0-bedf-ed68c97be46c.png)

![スクリーンショット 2022-04-21 14 37 17](https://user-images.githubusercontent.com/58643754/164381951-474face4-69e2-45bb-890b-49d0e1faeeb9.png)

