### PR TITLE
ActionMailerにGmailを設定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ end
 
 group :development do
   gem 'html2slim'
+  gem 'letter_opener_web', '~> 2.0'
   gem 'listen', '~> 3.3'
   gem 'rubocop-fjord', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,15 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -294,6 +303,7 @@ DEPENDENCIES
   factory_bot_rails
   html2slim
   jbuilder (~> 2.7)
+  letter_opener_web (~> 2.0)
   listen (~> 3.3)
   nokogiri
   open-uri (= 0.1.0)

--- a/app/javascript/edit-form.vue
+++ b/app/javascript/edit-form.vue
@@ -72,7 +72,7 @@
         <div class='container'>
           <div class='diary__item'>
             <div class='control'>
-              <button class='' onclick="return confirm('本当に削除しますか?')">削除</button>
+              <button class='button is-small' type='button' onclick="return confirm('本当に削除しますか?')">削除</button>
             </div>
           </div>
         </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.delivery_method = :letter_opener_web
+
   config.action_mailer.default_url_options = { host: 'example.com' }
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,12 +68,13 @@ Rails.application.configure do
   host = 'my-ground.herokuapp.com'
   config.action_mailer.default_url_options = { host: host }
   ActionMailer::Base.smtp_settings = {
-    :port           => ENV['MAILGUN_SMTP_PORT'],
-    :address        => ENV['MAILGUN_SMTP_SERVER'],
-    :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
-    :password       => ENV['MAILGUN_SMTP_PASSWORD'],
-    :domain         => host,
-    :authentication => :plain,
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: 'gmail.com',
+    user_name: Rails.application.credentials.gmail[:user_name],
+    password: Rails.application.credentials.gmail[:password],
+    authentication: :plain,
+    enable_starttle_auto: true
   }
   ActionMailer::Base.delivery_method = :smtp
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,6 @@ Rails.application.routes.draw do
   scope ':username' do
     resources :diaries
   end
+
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
issue #233 

HerokuのMailgunを使用していたが、Gmailアカウントを取得し送信元のメールアドレスとして設定した。